### PR TITLE
#9 Fix python benchmarks

### DIFF
--- a/atomspace/atomspace/AtomSpaceBenchmark.cc
+++ b/atomspace/atomspace/AtomSpaceBenchmark.cc
@@ -702,14 +702,14 @@ clock_t AtomSpaceBenchmark::makeRandomLinks()
         for (unsigned int i = 0; i<Nclock; i++)
         {
             Type t = ta[i];
-            HandleSeq outgoing = og[i];
+            const auto& outgoing = og[i];
             size_t arity = outgoing.size();
 
             OC_ASSERT(1 == Nloops, "Looping not supported for python");
             std::ostringstream dss;
             dss << "aspace.add_link (" << t << ", [";
             for (size_t j=0; j < arity; j++) {
-                dss << "Handle( " << outgoing[j].value() << ")";
+                dss << "Atom( " << &(outgoing[j]) << ", aspace)";
                 if (j < arity-1) dss  << ", ";
             }
             dss << " ] )\n";

--- a/atomspace/atomspace/AtomSpaceBenchmark.cc
+++ b/atomspace/atomspace/AtomSpaceBenchmark.cc
@@ -902,7 +902,6 @@ timepair_t AtomSpaceBenchmark::bm_rmAtom()
     switch (testKind) {
 #if HAVE_CYTHON
     case BENCH_PYTHON: {
-        OC_ASSERT(1 == Nloops, "Looping not supported for python");
         std::string psa[Nclock];
         for (unsigned int i=0; i<Nclock; i++)
         {
@@ -993,7 +992,6 @@ timepair_t AtomSpaceBenchmark::bm_getType()
     switch (testKind) {
 #if HAVE_CYTHON
     case BENCH_PYTHON: {
-        OC_ASSERT(1 == Nloops, "Looping not supported for python");
         std::string psa[Nclock];
         for (unsigned int i=0; i<Nclock; i++)
         {

--- a/atomspace/atomspace/AtomSpaceBenchmark.cc
+++ b/atomspace/atomspace/AtomSpaceBenchmark.cc
@@ -43,8 +43,6 @@ using std::time;
 
 TLB tlbuf;
 
-#define HAVE_CYTHONX 1
-
 AtomSpaceBenchmark::AtomSpaceBenchmark()
 {
     percentLinks = 0.2;
@@ -467,7 +465,7 @@ void AtomSpaceBenchmark::startBenchmark(int numThreads)
         }
         else {
             asp = new AtomSpace();
-#if HAVE_CYTHONX
+#if HAVE_CYTHON
             pyev = new PythonEval(asp);
             // And now ... create a Python instance of the atomspace.
             // Pass in the raw C++ atomspace address into cython.
@@ -497,7 +495,7 @@ void AtomSpaceBenchmark::startBenchmark(int numThreads)
 #if HAVE_GUILE
             delete scm;
 #endif
-#if HAVE_CYTHONX
+#if HAVE_CYTHON
             delete pyev;
 #endif
             delete asp;
@@ -645,7 +643,6 @@ clock_t AtomSpaceBenchmark::makeRandomNodes(const std::string& csi)
 
 #if HAVE_CYTHON
     case BENCH_PYTHON: {
-#if HAVE_CYTHONX
         std::string psa[Nclock];
 
         for (unsigned int i=0; i<Nclock; i++)
@@ -666,7 +663,6 @@ clock_t AtomSpaceBenchmark::makeRandomNodes(const std::string& csi)
         for (unsigned int i = 0; i < Nclock; ++i)
             pyev->eval(psa[i]);
         return clock() - t_begin;
-#endif /* HAVE_CYTHON */
     }
 #endif /* HAVE_CYTHON */
     }
@@ -702,7 +698,6 @@ clock_t AtomSpaceBenchmark::makeRandomLinks()
     switch (testKind) {
 #if HAVE_CYTHON
     case BENCH_PYTHON: {
-#if HAVE_CYTHONX
         std::string psa[Nclock];
         for (unsigned int i = 0; i<Nclock; i++)
         {
@@ -725,7 +720,6 @@ clock_t AtomSpaceBenchmark::makeRandomLinks()
         for (unsigned int i=0; i<Nclock; i++)
             pyev->eval(psa[i]);
         return clock() - t_begin;
-#endif /* HAVE_CYTHON */
     }
 #endif /* HAVE_CYTHON */
 
@@ -909,7 +903,6 @@ timepair_t AtomSpaceBenchmark::bm_rmAtom()
 #if HAVE_CYTHON
     case BENCH_PYTHON: {
         OC_ASSERT(1 == Nloops, "Looping not supported for python");
-#if HAVE_CYTHONX
         std::string psa[Nclock];
         for (unsigned int i=0; i<Nclock; i++)
         {
@@ -932,7 +925,6 @@ timepair_t AtomSpaceBenchmark::bm_rmAtom()
             pyev->eval(psa[i]);
         clock_t time_taken = clock() - t_begin;
         return timepair_t(time_taken,0);
-#endif /* HAVE_CYTHON */
     }
 #endif /* HAVE_CYTHON */
 #if HAVE_GUILE
@@ -1002,7 +994,6 @@ timepair_t AtomSpaceBenchmark::bm_getType()
 #if HAVE_CYTHON
     case BENCH_PYTHON: {
         OC_ASSERT(1 == Nloops, "Looping not supported for python");
-#if HAVE_CYTHONX
         std::string psa[Nclock];
         for (unsigned int i=0; i<Nclock; i++)
         {
@@ -1020,7 +1011,6 @@ timepair_t AtomSpaceBenchmark::bm_getType()
             pyev->eval(psa[i]);
         clock_t time_taken = clock() - t_begin;
         return timepair_t(time_taken,0);
-#endif /* HAVE_CYTHON */
     }
 #endif /* HAVE_CYTHON */
 
@@ -1070,7 +1060,6 @@ timepair_t AtomSpaceBenchmark::bm_getTruthValue()
     switch (testKind) {
 #if HAVE_CYTHON
     case BENCH_PYTHON: {
-#if HAVE_CYTHONX
         OC_ASSERT(1 == Nloops, "Looping not supported for python");
         std::string psa[Nclock];
         for (unsigned int i=0; i<Nclock; i++)
@@ -1086,7 +1075,6 @@ timepair_t AtomSpaceBenchmark::bm_getTruthValue()
             pyev->eval(psa[i]);
         clock_t time_taken = clock() - t_begin;
         return timepair_t(time_taken,0);
-#endif /* HAVE_CYTHON */
     }
 #endif /* HAVE_CYTHON */
 #if HAVE_GUILE
@@ -1147,7 +1135,6 @@ timepair_t AtomSpaceBenchmark::bm_setTruthValue()
     switch (testKind) {
 #if HAVE_CYTHON
     case BENCH_PYTHON: {
-#if HAVE_CYTHONX
         OC_ASSERT(1 == Nloops, "Looping not supported for python");
         std::string psa[Nclock];
         for (unsigned int i=0; i<Nclock; i++)
@@ -1166,7 +1153,6 @@ timepair_t AtomSpaceBenchmark::bm_setTruthValue()
             pyev->eval(psa[i]);
         clock_t time_taken = clock() - t_begin;
         return timepair_t(time_taken,0);
-#endif /* HAVE_CYTHON */
     }
 #endif /* HAVE_CYTHON */
 #if HAVE_GUILE
@@ -1221,7 +1207,6 @@ timepair_t AtomSpaceBenchmark::bm_getIncomingSet()
     switch (testKind) {
 #if HAVE_CYTHON
     case BENCH_PYTHON: {
-#if HAVE_CYTHONX
         OC_ASSERT(1 == Nloops, "Looping not supported for python");
         std::string psa[Nclock];
         for (unsigned int i=0; i<Nclock; i++)
@@ -1237,7 +1222,6 @@ timepair_t AtomSpaceBenchmark::bm_getIncomingSet()
             pyev->eval(psa[i]);
         clock_t time_taken = clock() - t_begin;
         return timepair_t(time_taken,0);
-#endif /* HAVE_CYTHON */
     }
 #endif /* HAVE_CYTHON */
 #if HAVE_GUILE
@@ -1361,7 +1345,6 @@ timepair_t AtomSpaceBenchmark::bm_getOutgoingSet()
 #if HAVE_CYTHON
     case BENCH_PYTHON: {
         OC_ASSERT(1 == Nloops, "Looping not supported for python");
-#if HAVE_CYTHONX
         std::string psa[Nclock];
         for (unsigned int i=0; i<Nclock; i++)
         {
@@ -1376,7 +1359,6 @@ timepair_t AtomSpaceBenchmark::bm_getOutgoingSet()
             pyev->eval(psa[i]);
         clock_t time_taken = clock() - t_begin;
         return timepair_t(time_taken,0);
-#endif /* HAVE_CYTHON */
     }
 #endif /* HAVE_CYTHON */
 #if HAVE_GUILE

--- a/atomspace/atomspace/AtomSpaceBenchmark.cc
+++ b/atomspace/atomspace/AtomSpaceBenchmark.cc
@@ -631,22 +631,6 @@ clock_t AtomSpaceBenchmark::makeRandomNodes(const std::string& csi)
                 ss << "(cog-new-node '"
                    << nameserver().getTypeName(t)
                    << " \"" << scp << "\")\n";
-
-                p = randomGenerator->randdouble();
-                t = defaultNodeType;
-                if (p < chanceOfNonDefaultNode)
-                    t = randomType(NODE);
-
-                scp = csi;
-                if (csi.size() ==  0) {
-                    std::ostringstream oss;
-                    counter++;
-                    if (NUMBER_NODE == t)
-                        oss << counter;  // number nodes must actually be numbers.
-                    else
-                        oss << "node " << counter;
-                    scp = oss.str();
-                }
             }
             std::string gs = memoize_or_compile(ss.str());
             gsa[i] = gs;
@@ -673,22 +657,6 @@ clock_t AtomSpaceBenchmark::makeRandomNodes(const std::string& csi)
             for (unsigned int i=0; i<Nloops; i++) {
                 if (memoize) dss << "    ";   // indentation
                 dss << "aspace.add_node (" << t << ", \"" << scp << "\")\n";
-
-                p = randomGenerator->randdouble();
-                t = defaultNodeType;
-                if (p < chanceOfNonDefaultNode)
-                    t = randomType(NODE);
-
-                scp = csi;
-                if (csi.size() ==  0) {
-                    std::ostringstream oss;
-                    counter++;
-                    if (NUMBER_NODE == t)
-                        oss << counter;  // number nodes must actually be numbers.
-                    else
-                        oss << "node " << counter;
-                    scp = oss.str();
-                }
             }
 
             std::string ps = memoize_or_compile(dss.str());
@@ -790,21 +758,6 @@ clock_t AtomSpaceBenchmark::makeRandomLinks()
                     ss << " h" << c;
                 }
                 ss << ")\n";
-
-                t = defaultLinkType;
-                p = randomGenerator->randdouble();
-                if (p < chanceOfNonDefaultLink) t = randomType(LINK);
-
-                arity = (*poissonDistribution)(*randomGenerator);
-                if (arity == 0) { ++arity; };
-
-                // AtomSpace will throw if the context link has bad arity
-                if (CONTEXT_LINK == t) arity = 2;
-
-                outgoing.clear();
-                for (size_t j=0; j < arity; j++) {
-                    outgoing.push_back(getRandomHandle());
-                }
             }
             std::string gs = memoize_or_compile(ss.str());
             gsa[i] = gs;

--- a/atomspace/atomspace/AtomSpaceBenchmark.cc
+++ b/atomspace/atomspace/AtomSpaceBenchmark.cc
@@ -476,7 +476,7 @@ void AtomSpaceBenchmark::startBenchmark(int numThreads)
             // run on a different atomspace, than the one containing
             // all the atoms.  And that would give bad results.
             std::ostringstream dss;
-            dss << "from opencog.atomspace import AtomSpace, types, TruthValue" << std::endl;
+            dss << "from opencog.atomspace import AtomSpace, types, TruthValue, Atom" << std::endl;
             dss << "aspace = AtomSpace(" << asp << ")" << std::endl;
             pyev->eval(dss.str());
 #endif
@@ -916,7 +916,7 @@ timepair_t AtomSpaceBenchmark::bm_rmAtom()
             Handle h = hs[i];
             std::ostringstream dss;
             for (unsigned int i=0; i<Nloops; i++) {
-                dss << "aspace.remove(Handle(" << h.value() << "))\n";
+                dss << "aspace.remove(Atom(" << &h << ", aspace))\n";
                 h = getRandomHandle();
                 // XXX FIXME --- this may have trouble finding anything if
                 // Nloops is bigger than the number of links in the atomspace !
@@ -1009,7 +1009,7 @@ timepair_t AtomSpaceBenchmark::bm_getType()
             Handle h = hs[i];
             std::ostringstream dss;
             for (unsigned int i=0; i<Nloops; i++) {
-                dss << "aspace.get_type(Handle(" << h.value() << "))\n";
+                dss << "type = Atom(" << &h << ", aspace)" << ".type\n";
                 h = getRandomHandle();
             }
             std::string ps = dss.str();
@@ -1077,7 +1077,7 @@ timepair_t AtomSpaceBenchmark::bm_getTruthValue()
         {
             Handle h = hs[i];
             std::ostringstream dss;
-            dss << "aspace.get_tv(Handle(" << h.value() << "))\n";
+            dss << "tv = Atom(" << &h << ", aspace).tv\n";
             std::string ps = dss.str();
             psa[i] = ps;
         }
@@ -1156,8 +1156,8 @@ timepair_t AtomSpaceBenchmark::bm_setTruthValue()
             float strength = strg[i];
             float cnf = conf[i];
             std::ostringstream dss;
-            dss << "aspace.set_tv(Handle(" << h.value()
-                << "), TruthValue(" << strength << ", " << cnf << "))\n";
+            dss << "Atom(" << &h <<", aspace)"
+                << ".truth_value(" << strength << ", " << cnf << ")\n";
             std::string ps = dss.str();
             psa[i] = ps;
         }
@@ -1228,7 +1228,7 @@ timepair_t AtomSpaceBenchmark::bm_getIncomingSet()
         {
             Handle h = hs[i];
             std::ostringstream dss;
-            dss << "incoming = Atom(" << h.value() << ").incoming\n";
+            dss << "incoming = Atom(" << &h << ", aspace).incoming\n";
             std::string ps = dss.str();
             psa[i] = ps;
         }
@@ -1367,7 +1367,7 @@ timepair_t AtomSpaceBenchmark::bm_getOutgoingSet()
         {
             Handle h = hs[i];
             std::ostringstream dss;
-            dss << "out = Atom(" << h.value() << ", aspace).out\n";
+            dss << "out = Atom(" << &h << ", aspace).out\n";
             std::string ps = dss.str();
             psa[i] = ps;
         }
@@ -1427,7 +1427,8 @@ timepair_t AtomSpaceBenchmark::bm_getHandlesByType()
         std::string ps = dss.str();
         clock_t t_begin = clock();
         pyev->eval(ps);
-        return timepair_t(Nclock*clock(), Nclock*t_begin);
+        clock_t time_taken = clock() - t_begin;
+        return timepair_t(Nclock*time_taken,0);
     }
 #endif /* HAVE_CYTHON */
 #if HAVE_GUILE

--- a/atomspace/atomspace/CMakeLists.txt
+++ b/atomspace/atomspace/CMakeLists.txt
@@ -17,5 +17,6 @@ IF (HAVE_CYTHON)
         TARGET_LINK_LIBRARIES (atomspace_bm
                 ${Boost_SYSTEM_LIBRARY}
                 ${PYTHON_LIBRARIES}
+                ${ATOMSPACE_PythonEval_LIBRARY}
         )
 ENDIF(HAVE_CYTHON)


### PR DESCRIPTION
Python benchmarks are implemented using Guile implementation as reference. Changes in Python bindings API are applied.

Link https://github.com/opencog/benchmark/pull/12/files?w=1 ignores spaces and makes code alignment is more relevant.

Python results:
```
$ ./atomspace/atomspace/atomspace_bm -A -c
OpenCog Atomspace Benchmark - Version 1.0.1

Random generator: MT19937
Random seed: 1527164403

Benchmarking Python's noop method 400000 times ..........
0.023060 seconds elapsed (17346170.39 per second)
Sum clock() time for all requests: 131 (0.000131 seconds, 3.05344e+09 requests per second)
------------------------------
Benchmarking Python's getType method 400000 times ..........
7.586225 seconds elapsed (52727.15 per second)
Sum clock() time for all requests: 7004312 (7.00431 seconds, 57107.7 requests per second)
------------------------------
Benchmarking Python's getTruthValue method 400000 times ..........
8.982693 seconds elapsed (44530.08 per second)
Sum clock() time for all requests: 8596201 (8.5962 seconds, 46532.2 requests per second)
------------------------------
Benchmarking Python's setTruthValue method 400000 times ..........
10.471440 seconds elapsed (38199.14 per second)
Sum clock() time for all requests: 9861954 (9.86195 seconds, 40559.9 requests per second)
------------------------------
Benchmarking Python's pointerCast method 400000 times ..........
0.190754 seconds elapsed (2096942.31 per second)
Sum clock() time for all requests: 0 (0 seconds, inf requests per second)
------------------------------
Benchmarking Python's getIncomingSet method 400000 times ..........
8.424081 seconds elapsed (47482.92 per second)
Sum clock() time for all requests: 8034402 (8.0344 seconds, 49785.9 requests per second)
------------------------------
Benchmarking Python's getIncomingSetSize method 400000 times ..........
0.187442 seconds elapsed (2133992.72 per second)
Sum clock() time for all requests: 0 (0 seconds, inf requests per second)
------------------------------
Benchmarking Python's getOutgoingSet method 400000 times ..........
7.629716 seconds elapsed (52426.59 per second)
Sum clock() time for all requests: 7233621 (7.23362 seconds, 55297.3 requests per second)
------------------------------
Benchmarking Python's addNode method 400000 times ..........
13.503772 seconds elapsed (29621.35 per second)
Sum clock() time for all requests: 13077400 (13.0774 seconds, 30587.1 requests per second)
------------------------------
Benchmarking Python's addLink method 400000 times ..........
22.010627 seconds elapsed (18173.04 per second)
Sum clock() time for all requests: 21142408 (21.1424 seconds, 18919.3 requests per second)
------------------------------
Benchmarking Python's removeAtom method 194000 times ...........
4.535461 seconds elapsed (42774.04 per second)
Sum clock() time for all requests: 3858507 (3.85851 seconds, 50278.5 requests per second)
------------------------------
Benchmarking Python's getHandlesByType method 400000 times ..........
2.239153 seconds elapsed (178638.98 per second)
Sum clock() time for all requests: 4474066000 (4474.07 seconds, 89.4041 requests per second)
------------------------------
Benchmarking Python's push_back method 400000 times ..........
0.000836 seconds elapsed (478528693.67 per second)
Sum clock() time for all requests: 0 (0 seconds, inf requests per second)
------------------------------
Benchmarking Python's push_back_reserve method 400000 times ..........
0.000828 seconds elapsed (483214746.54 per second)
Sum clock() time for all requests: 0 (0 seconds, inf requests per second)
------------------------------
Benchmarking Python's emplace_back method 400000 times ..........
0.000830 seconds elapsed (481965412.24 per second)
Sum clock() time for all requests: 0 (0 seconds, inf requests per second)
------------------------------
Benchmarking Python's emplace_back_reserve method 400000 times ..........
0.000840 seconds elapsed (476219585.58 per  #second)
Sum clock() time for all requests: 0 (0 seconds, inf requests per second)
------------------------------
Benchmarking Python's reserve method 400000 times ..........
0.000837 seconds elapsed (477847223.01 per second)
Sum clock() time for all requests: 0 (0 seconds, inf requests per second)
------------------------------

```
C++ results:
```
$ ./atomspace/atomspace/atomspace_bm -A
OpenCog Atomspace Benchmark - Version 1.0.1

Random generator: MT19937
Random seed: 1527164611

Benchmarking AtomSpace's noop method 400000 times ..........
0.022912 seconds elapsed (17458081.17 per second)
Sum clock() time for all requests: 136 (0.000136 seconds, 2.94118e+09 requests per second)
------------------------------
Benchmarking AtomSpace's getType method 400000 times ..........
0.175667 seconds elapsed (2277034.91 per second)
Sum clock() time for all requests: 2931 (0.002931 seconds, 1.36472e+08 requests per second)
------------------------------
Benchmarking AtomSpace's getTruthValue method 400000 times ..........
0.236796 seconds elapsed (1689216.72 per second)
Sum clock() time for all requests: 59137 (0.059137 seconds, 6.76396e+06 requests per second)
------------------------------
Benchmarking AtomSpace's setTruthValue method 400000 times ..........
0.606672 seconds elapsed (659334.81 per second)
Sum clock() time for all requests: 401896 (0.401896 seconds, 995282 requests per second)
------------------------------
Benchmarking AtomSpace's pointerCast method 400000 times ..........
0.212977 seconds elapsed (1878137.67 per second)
Sum clock() time for all requests: 24430 (0.02443 seconds, 1.63733e+07 requests per second)
------------------------------
Benchmarking AtomSpace's getIncomingSet method 400000 times ..........
0.367629 seconds elapsed (1088053.29 per second)
Sum clock() time for all requests: 176175 (0.176175 seconds, 2.27047e+06 requests per second)
------------------------------
Benchmarking AtomSpace's getIncomingSetSize method 400000 times ..........
0.295474 seconds elapsed (1353756.77 per second)
Sum clock() time for all requests: 81679 (0.081679 seconds, 4.89722e+06 requests per second)
------------------------------
Benchmarking AtomSpace's getOutgoingSet method 400000 times ..........
0.184256 seconds elapsed (2170891.77 per second)
Sum clock() time for all requests: 4991 (0.004991 seconds, 8.01443e+07 requests per second)
------------------------------
Benchmarking AtomSpace's addNode method 400000 times ..........
2.152410 seconds elapsed (185838.22 per second)
Sum clock() time for all requests: 1866968 (1.86697 seconds, 214251 requests per second)
------------------------------
Benchmarking AtomSpace's addLink method 400000 times ..........
4.436075 seconds elapsed (90169.80 per second)
Sum clock() time for all requests: 3860118 (3.86012 seconds, 103624 requests per second)
------------------------------
Benchmarking AtomSpace's removeAtom method 194000 times ...........
0.729076 seconds elapsed (266090.26 per second)
Sum clock() time for all requests: 389898 (0.389898 seconds, 497566 requests per second)
------------------------------
Benchmarking AtomSpace's getHandlesByType method 400000 times ..........
1.210773 seconds elapsed (330367.46 per second)
Sum clock() time for all requests: 2257008000 (2257.01 seconds, 177.226 requests per second)
------------------------------
Benchmarking AtomSpace's push_back method 400000 times ..........
0.000837 seconds elapsed (477847223.01 per second)
Sum clock() time for all requests: 0 (0 seconds, inf requests per second)
------------------------------
Benchmarking AtomSpace's push_back_reserve method 400000 times ..........
0.000843 seconds elapsed (474468778.28 per second)
Sum clock() time for all requests: 0 (0 seconds, inf requests per second)
------------------------------
Benchmarking AtomSpace's emplace_back method 400000 times ..........
0.000864 seconds elapsed (462947461.37 per second)
Sum clock() time for all requests: 0 (0 seconds, inf requests per second)
------------------------------
Benchmarking AtomSpace's emplace_back_reserve method 400000 times ..........
0.000894 seconds elapsed (447511763.14 per second)
Sum clock() time for all requests: 0 (0 seconds, inf requests per second)
------------------------------
Benchmarking AtomSpace's reserve method 400000 times ..........
0.000886 seconds elapsed (451485898.82 per second)
Sum clock() time for all requests: 0 (0 seconds, inf requests per second)
------------------------------
```