### PR TITLE
Issue #8 Add ScopeLink benchmarks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -258,6 +258,11 @@ IF(HAVE_PY_INTERP)
 	ENDIF (NOSETESTS_EXECUTABLE AND CYTHON_FOUND AND HAVE_PY_LIBS)
 ENDIF(HAVE_PY_INTERP)
 
+FIND_PACKAGE(benchmark CONFIG REQUIRED)
+IF (benchmark_FOUND)
+	MESSAGE(STATUS "Google Benchmark ${benchmark_VERSION} found.")
+ENDIF(benchmark_FOUND)
+
 # ===================================================================
 # Add subdirectories
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,21 @@ centralized here, with the folder names (under that root folder) equal
 to names of the repositories being benchmarked. As well as likely some
 common tools placed under some common folder.
 
+## Prerequisites
+
+### Google Benchmarks
+
+Google Benchmark is a library supporting C++ benchmarks writing. Use following commands to build and install it:
+
+```
+    git clone https://github.com/google/benchmark.git google-benchmark
+    mkdir google-benchmark/build
+    cd google-benchmark/build
+    cmake -DCMAKE_BUILD_TYPE=Release -DBENCHMARK_ENABLE_GTEST_TESTS=OFF ..
+    make
+    sudo make install
+```
+
 ## Building Benchmarks
 
 Perform the following steps at the shell prompt:
@@ -20,3 +35,4 @@ Perform the following steps at the shell prompt:
     cmake ..
     make
 ```
+

--- a/atomspace/atomspace/CMakeLists.txt
+++ b/atomspace/atomspace/CMakeLists.txt
@@ -11,13 +11,13 @@ TARGET_LINK_LIBRARIES (atomspace_bm
 )
 
 IF (benchmark_FOUND)
-        ADD_EXECUTABLE (scopelink_bm
+        ADD_EXECUTABLE (benchmark
                 benchmark.cc
                 scopelink_bm.cc
                 evaluationlink_bm.cc
         )
         
-        TARGET_LINK_LIBRARIES (scopelink_bm
+        TARGET_LINK_LIBRARIES (benchmark
                 ${ATOMSPACE_LIBRARIES}
                 ${COGUTIL_LIBRARY}
                 benchmark::benchmark

--- a/atomspace/atomspace/CMakeLists.txt
+++ b/atomspace/atomspace/CMakeLists.txt
@@ -10,6 +10,21 @@ TARGET_LINK_LIBRARIES (atomspace_bm
         ${COGUTIL_LIBRARY}
 )
 
+IF (benchmark_FOUND)
+        ADD_EXECUTABLE (scopelink_bm
+                benchmark.cc
+                scopelink_bm.cc
+                evaluationlink_bm.cc
+        )
+        
+        TARGET_LINK_LIBRARIES (scopelink_bm
+                ${ATOMSPACE_LIBRARIES}
+                ${COGUTIL_LIBRARY}
+                benchmark::benchmark
+                benchmark::benchmark_main
+        )
+ENDIF(benchmark_FOUND)
+
 IF (HAVE_CYTHON)
         INCLUDE_DIRECTORIES (
                 ${PYTHON_INCLUDE_DIRS}

--- a/atomspace/atomspace/README.md
+++ b/atomspace/atomspace/README.md
@@ -134,3 +134,30 @@ optional arguments:
                           scheme    - scheme evaluation functions
   -i N, --iterations N  iterations to average (default=10)
 ```
+
+# Google Benchmark based benchmarks
+
+Run benchmarks:
+
+```
+cd <BUILD_DIR>/atomspace/atomspace
+./benchmark
+```
+
+Benchmark command line parameters:
+
+```
+benchmark [--benchmark_list_tests={true|false}]
+          [--benchmark_filter=<regex>]
+          [--benchmark_min_time=<min_time>]
+          [--benchmark_repetitions=<num_repetitions>]
+          [--benchmark_report_aggregates_only={true|false}
+          [--benchmark_format=<console|json|csv>]
+          [--benchmark_out=<filename>]
+          [--benchmark_out_format=<json|console|csv>]
+          [--benchmark_color={auto|true|false}]
+          [--benchmark_counters_tabular={true|false}]
+          [--v=<verbosity>]
+```
+
+See Google Benchmark documentation https://github.com/google/benchmark/blob/master/README.md and ```DEFINE_*``` definitions in https://github.com/google/benchmark/blob/master/src/benchmark.cc for command line parameters explanation.

--- a/atomspace/atomspace/benchmark.cc
+++ b/atomspace/atomspace/benchmark.cc
@@ -1,0 +1,44 @@
+/*
+ * benchmark.cc
+ *
+ * Copyright (C) 2018 OpenCog Foundation
+ * All Rights Reserved
+ *
+ * Created by Vitaly Bogdanov <vsbogd@gmail.com> May 29, 2018
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License v3 as
+ * published by the Free Software Foundation and including the exceptions
+ * at http://opencog.org/wiki/Licenses
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program; if not, write to:
+ * Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include <benchmark/benchmark.h>
+#include <sstream>
+
+#include <opencog/util/Logger.h>
+
+using namespace opencog;
+
+std::string get_unique_name(const std::string& prefix, size_t& seed)
+{
+	std::ostringstream oss;
+	oss << prefix << "-" << ++seed;
+	return oss.str();
+}
+
+int main(int argc, char** argv)
+{
+	logger().set_level(Logger::FINE);
+	benchmark::Initialize(&argc, argv);
+	benchmark::RunSpecifiedBenchmarks();
+}

--- a/atomspace/atomspace/benchmark.h
+++ b/atomspace/atomspace/benchmark.h
@@ -1,0 +1,32 @@
+/*
+ * benchmark.h
+ *
+ * Copyright (C) 2018 OpenCog Foundation
+ * All Rights Reserved
+ *
+ * Created by Vitaly Bogdanov <vsbogd@gmail.com> May 29, 2018
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License v3 as
+ * published by the Free Software Foundation and including the exceptions
+ * at http://opencog.org/wiki/Licenses
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program; if not, write to:
+ * Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#ifndef ATOMSPACE_ATOMSPACE_BENCHMARK_H_
+#define ATOMSPACE_ATOMSPACE_BENCHMARK_H_
+
+#include <string>
+
+std::string get_unique_name(const std::string& prefix, size_t& seed);
+
+#endif /* ATOMSPACE_ATOMSPACE_BENCHMARK_H_ */

--- a/atomspace/atomspace/evaluationlink_bm.cc
+++ b/atomspace/atomspace/evaluationlink_bm.cc
@@ -99,7 +99,7 @@ static void BM_AddEvaluationLink(benchmark::State& state)
 
 	logger().fine("atomspace size after adding: %d", atomspace.get_size());
 }
-BENCHMARK(BM_AddEvaluationLink)->Arg(2<<15);
+BENCHMARK(BM_AddEvaluationLink)->Arg(2<<13)->Arg(2<<14)->Arg(2<<15);
 
 
 

--- a/atomspace/atomspace/evaluationlink_bm.cc
+++ b/atomspace/atomspace/evaluationlink_bm.cc
@@ -99,7 +99,7 @@ static void BM_AddEvaluationLink(benchmark::State& state)
 
 	logger().fine("atomspace size after adding: %d", atomspace.get_size());
 }
-BENCHMARK(BM_AddEvaluationLink)->Range(2, 2<<13);
+BENCHMARK(BM_AddEvaluationLink)->Arg(2<<15);
 
 
 

--- a/atomspace/atomspace/evaluationlink_bm.cc
+++ b/atomspace/atomspace/evaluationlink_bm.cc
@@ -1,0 +1,106 @@
+/*
+ * evaluationlink_bm.cc
+ *
+ * Copyright (C) 2018 OpenCog Foundation
+ * All Rights Reserved
+ *
+ * Created by Vitaly Bogdanov <vsbogd@gmail.com> May 29, 2018
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License v3 as
+ * published by the Free Software Foundation and including the exceptions
+ * at http://opencog.org/wiki/Licenses
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program; if not, write to:
+ * Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include <benchmark/benchmark.h>
+
+#include <opencog/util/Logger.h>
+#include <opencog/atoms/base/Atom.h>
+#include <opencog/atoms/base/Node.h>
+#include <opencog/atoms/base/Link.h>
+#include <opencog/atomspace/AtomSpace.h>
+
+#include "benchmark.h"
+
+using namespace opencog;
+
+static Handle create_evaluation_link(AtomSpace& atomspace, size_t& seed)
+{
+	Handle X = atomspace.add_node(VARIABLE_NODE, get_unique_name("$X", seed));
+	Handle P = atomspace.add_node(PREDICATE_NODE, get_unique_name("P", seed));
+	return createLink(EVALUATION_LINK, P, X);
+}
+
+static Handle create_evaluation_link(AtomSpace& atomspace)
+{
+	size_t seed = 0;
+	return create_evaluation_link(atomspace, seed);
+}
+
+static void BM_CreateEvaluationLink(benchmark::State& state)
+{
+	AtomSpace atomspace;
+	Handle X = atomspace.add_node(VARIABLE_NODE, "$X");
+	Handle P = atomspace.add_node(PREDICATE_NODE, "P");
+
+	for (auto _ : state)
+	{
+		createLink(EVALUATION_LINK, P, X);
+	}
+}
+BENCHMARK(BM_CreateEvaluationLink);
+
+static void BM_AddSameEvaluationLink(benchmark::State& state)
+{
+	AtomSpace atomspace;
+	Handle evaluationLink = create_evaluation_link(atomspace);
+
+	logger().fine("atomspace size before adding: %d", atomspace.get_size());
+
+	for (auto _ : state)
+	{
+		atomspace.add_atom(evaluationLink);
+	}
+
+	logger().fine("atomspace size after adding: %d", atomspace.get_size());
+
+}
+BENCHMARK(BM_AddSameEvaluationLink);
+
+static void BM_AddEvaluationLink(benchmark::State& state)
+{
+	AtomSpace atomspace;
+
+	const size_t number_of_links = state.range(0);
+	std::vector<Handle> links(number_of_links);
+	size_t seed = 0;
+	for (size_t i = 0; i < number_of_links; ++i)
+	{
+		links[i] = create_evaluation_link(atomspace, seed);
+	}
+
+	logger().fine("atomspace size before adding: %d", atomspace.get_size());
+
+	size_t i = 0;
+	for (auto _ : state)
+	{
+		atomspace.add_atom(links[i++ % number_of_links]);
+	}
+
+	logger().fine("atomspace size after adding: %d", atomspace.get_size());
+}
+BENCHMARK(BM_AddEvaluationLink)->Range(2, 2<<13);
+
+
+
+

--- a/atomspace/atomspace/scopelink_bm.cc
+++ b/atomspace/atomspace/scopelink_bm.cc
@@ -152,5 +152,5 @@ static void BM_AddScopeLink(benchmark::State& state)
 
 	logger().fine("atomspace size after adding: %d", atomspace.get_size());
 }
-BENCHMARK(BM_AddScopeLink)->Range(2, 2<<13);
+BENCHMARK(BM_AddScopeLink)->Arg(2<<15);
 

--- a/atomspace/atomspace/scopelink_bm.cc
+++ b/atomspace/atomspace/scopelink_bm.cc
@@ -1,0 +1,171 @@
+/*
+ * scopelink_bm.cc
+ *
+ * Copyright (C) 2018 OpenCog Foundation
+ * All Rights Reserved
+ *
+ * Created by Vitaly Bogdanov <vsbogd@gmail.com> May 28, 2018
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License v3 as
+ * published by the Free Software Foundation and including the exceptions
+ * at http://opencog.org/wiki/Licenses
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program; if not, write to:
+ * Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include <benchmark/benchmark.h>
+
+#include <opencog/util/Logger.h>
+#include <opencog/atoms/base/Atom.h>
+#include <opencog/atoms/base/Node.h>
+#include <opencog/atoms/base/Link.h>
+#include <opencog/atomspace/AtomSpace.h>
+#include <opencog/atoms/core/ScopeLink.h>
+
+#include "benchmark.h"
+
+using namespace opencog;
+
+static Handle create_scope_link(AtomSpace& atomspace, size_t& seed)
+{
+	Handle X = atomspace.add_node(VARIABLE_NODE, get_unique_name("$X", seed));
+	Handle Y = atomspace.add_node(VARIABLE_NODE, get_unique_name("$Y", seed));
+	Handle P = atomspace.add_node(PREDICATE_NODE, get_unique_name("P", seed));
+	Handle Q = atomspace.add_node(PREDICATE_NODE, get_unique_name("Q", seed));
+
+	Handle variable_list = atomspace.add_link(VARIABLE_LIST, X, Y);
+	Handle expression = atomspace.add_link(AND_LINK,
+	        atomspace.add_link(EVALUATION_LINK, P, X),
+	        atomspace.add_link(EVALUATION_LINK, Q, Y));
+	return createLink(SCOPE_LINK, variable_list, expression);
+}
+
+static Handle create_scope_link(AtomSpace& atomspace)
+{
+	size_t seed = 0;
+	return create_scope_link(atomspace, seed);
+}
+
+static void BM_CreateScopeLinkWithVariableList(benchmark::State& state)
+{
+	AtomSpace atomspace;
+
+	Handle X = atomspace.add_node(VARIABLE_NODE, "$X");
+	Handle Y = atomspace.add_node(VARIABLE_NODE, "$Y");
+	Handle P = atomspace.add_node(PREDICATE_NODE, "P");
+	Handle Q = atomspace.add_node(PREDICATE_NODE, "Q");
+
+	Handle variable_list = atomspace.add_link(VARIABLE_LIST, X, Y);
+	Handle expression = atomspace.add_link(AND_LINK,
+	        atomspace.add_link(EVALUATION_LINK, P, X),
+	        atomspace.add_link(EVALUATION_LINK, Q, Y));
+
+	Handle h;
+	for (auto _ : state)
+	{
+		h = createLink(SCOPE_LINK, variable_list, expression);
+	}
+
+	logger().fine(
+	        "variables: " + ((ScopeLink&) (*h)).get_variables().to_string());
+}
+BENCHMARK(BM_CreateScopeLinkWithVariableList);
+
+static void BM_CreateScopeLinkWithoutVariableList(benchmark::State& state)
+{
+	AtomSpace atomspace;
+
+	Handle X = atomspace.add_node(VARIABLE_NODE, "$X");
+	Handle Y = atomspace.add_node(VARIABLE_NODE, "$Y");
+	Handle P = atomspace.add_node(PREDICATE_NODE, "P");
+	Handle Q = atomspace.add_node(PREDICATE_NODE, "Q");
+
+	Handle expression = atomspace.add_link(AND_LINK,
+	        atomspace.add_link(EVALUATION_LINK, P, X),
+	        atomspace.add_link(EVALUATION_LINK, Q, Y));
+
+	Handle h;
+	for (auto _ : state)
+	{
+		h = createLink(SCOPE_LINK, expression);
+	}
+
+	logger().fine(
+	        "variables: " + ((ScopeLink&) (*h)).get_variables().to_string());
+}
+BENCHMARK(BM_CreateScopeLinkWithoutVariableList);
+
+static void BM_CreateScopeLinkWithLambdaLink(benchmark::State& state)
+{
+	AtomSpace atomspace;
+
+	Handle X = atomspace.add_node(VARIABLE_NODE, "$X");
+	Handle Y = atomspace.add_node(VARIABLE_NODE, "$Y");
+	Handle P = atomspace.add_node(PREDICATE_NODE, "P");
+	Handle Q = atomspace.add_node(PREDICATE_NODE, "Q");
+
+	Handle expression = atomspace.add_link(LAMBDA_LINK,
+	        atomspace.add_link(AND_LINK,
+	                atomspace.add_link(EVALUATION_LINK, P, X),
+	                atomspace.add_link(EVALUATION_LINK, Q, Y)));
+
+	Handle h;
+	for (auto _ : state)
+	{
+		h = createLink(SCOPE_LINK, expression);
+	}
+
+	logger().fine(
+	        "variables: " + ((ScopeLink&) (*h)).get_variables().to_string());
+}
+BENCHMARK(BM_CreateScopeLinkWithLambdaLink);
+
+static void BM_AddSameScopeLink(benchmark::State& state)
+{
+	AtomSpace atomspace;
+	Handle scopeLink = create_scope_link(atomspace);
+
+	logger().fine("atomspace size before adding: %d", atomspace.get_size());
+
+	for (auto _ : state)
+	{
+		atomspace.add_atom(scopeLink);
+	}
+
+	logger().fine("atomspace size after adding: %d", atomspace.get_size());
+}
+BENCHMARK(BM_AddSameScopeLink);
+
+static void BM_AddScopeLink(benchmark::State& state)
+{
+	AtomSpace atomspace;
+
+	const size_t number_of_links = state.range(0);
+	std::vector<Handle> links(number_of_links);
+	size_t seed = 0;
+	for (size_t i = 0; i < number_of_links; ++i)
+	{
+		links[i] = create_scope_link(atomspace, seed);
+	}
+
+	logger().fine("atomspace size before adding: %d", atomspace.get_size());
+
+	size_t i = 0;
+	for (auto _ : state)
+	{
+		atomspace.add_atom(links[i++ % number_of_links]);
+	}
+
+	logger().fine("atomspace size after adding: %d", atomspace.get_size());
+}
+BENCHMARK(BM_AddScopeLink)->Range(2, 2<<13);
+

--- a/atomspace/atomspace/scopelink_bm.cc
+++ b/atomspace/atomspace/scopelink_bm.cc
@@ -152,5 +152,5 @@ static void BM_AddScopeLink(benchmark::State& state)
 
 	logger().fine("atomspace size after adding: %d", atomspace.get_size());
 }
-BENCHMARK(BM_AddScopeLink)->Arg(2<<15);
+BENCHMARK(BM_AddScopeLink)->Arg(2<<11)->Arg(2<<12)->Arg(2<<13);
 

--- a/atomspace/atomspace/scopelink_bm.cc
+++ b/atomspace/atomspace/scopelink_bm.cc
@@ -38,14 +38,11 @@ using namespace opencog;
 static Handle create_scope_link(AtomSpace& atomspace, size_t& seed)
 {
 	Handle X = atomspace.add_node(VARIABLE_NODE, get_unique_name("$X", seed));
-	Handle Y = atomspace.add_node(VARIABLE_NODE, get_unique_name("$Y", seed));
 	Handle P = atomspace.add_node(PREDICATE_NODE, get_unique_name("P", seed));
-	Handle Q = atomspace.add_node(PREDICATE_NODE, get_unique_name("Q", seed));
 
-	Handle variable_list = atomspace.add_link(VARIABLE_LIST, X, Y);
-	Handle expression = atomspace.add_link(AND_LINK,
-	        atomspace.add_link(EVALUATION_LINK, P, X),
-	        atomspace.add_link(EVALUATION_LINK, Q, Y));
+	Handle variable_list = atomspace.add_link(VARIABLE_LIST, X);
+	Handle expression = atomspace.add_link(EVALUATION_LINK, P, X);
+
 	return createLink(SCOPE_LINK, variable_list, expression);
 }
 
@@ -60,14 +57,10 @@ static void BM_CreateScopeLinkWithVariableList(benchmark::State& state)
 	AtomSpace atomspace;
 
 	Handle X = atomspace.add_node(VARIABLE_NODE, "$X");
-	Handle Y = atomspace.add_node(VARIABLE_NODE, "$Y");
 	Handle P = atomspace.add_node(PREDICATE_NODE, "P");
-	Handle Q = atomspace.add_node(PREDICATE_NODE, "Q");
 
-	Handle variable_list = atomspace.add_link(VARIABLE_LIST, X, Y);
-	Handle expression = atomspace.add_link(AND_LINK,
-	        atomspace.add_link(EVALUATION_LINK, P, X),
-	        atomspace.add_link(EVALUATION_LINK, Q, Y));
+	Handle variable_list = atomspace.add_link(VARIABLE_LIST, X);
+	Handle expression = atomspace.add_link(EVALUATION_LINK, P, X);
 
 	Handle h;
 	for (auto _ : state)
@@ -85,13 +78,9 @@ static void BM_CreateScopeLinkWithoutVariableList(benchmark::State& state)
 	AtomSpace atomspace;
 
 	Handle X = atomspace.add_node(VARIABLE_NODE, "$X");
-	Handle Y = atomspace.add_node(VARIABLE_NODE, "$Y");
 	Handle P = atomspace.add_node(PREDICATE_NODE, "P");
-	Handle Q = atomspace.add_node(PREDICATE_NODE, "Q");
 
-	Handle expression = atomspace.add_link(AND_LINK,
-	        atomspace.add_link(EVALUATION_LINK, P, X),
-	        atomspace.add_link(EVALUATION_LINK, Q, Y));
+	Handle expression = atomspace.add_link(EVALUATION_LINK, P, X);
 
 	Handle h;
 	for (auto _ : state)
@@ -109,14 +98,10 @@ static void BM_CreateScopeLinkWithLambdaLink(benchmark::State& state)
 	AtomSpace atomspace;
 
 	Handle X = atomspace.add_node(VARIABLE_NODE, "$X");
-	Handle Y = atomspace.add_node(VARIABLE_NODE, "$Y");
 	Handle P = atomspace.add_node(PREDICATE_NODE, "P");
-	Handle Q = atomspace.add_node(PREDICATE_NODE, "Q");
 
 	Handle expression = atomspace.add_link(LAMBDA_LINK,
-	        atomspace.add_link(AND_LINK,
-	                atomspace.add_link(EVALUATION_LINK, P, X),
-	                atomspace.add_link(EVALUATION_LINK, Q, Y)));
+	        atomspace.add_link(EVALUATION_LINK, P, X));
 
 	Handle h;
 	for (auto _ : state)

--- a/atomspace/atomspace/scopelink_bm.cc
+++ b/atomspace/atomspace/scopelink_bm.cc
@@ -69,7 +69,7 @@ static void BM_CreateScopeLinkWithVariableList(benchmark::State& state)
 	}
 
 	logger().fine(
-	        "variables: " + ((ScopeLink&) (*h)).get_variables().to_string());
+	        "variables: " + ScopeLinkCast(h)->get_variables().to_string());
 }
 BENCHMARK(BM_CreateScopeLinkWithVariableList);
 
@@ -89,7 +89,7 @@ static void BM_CreateScopeLinkWithoutVariableList(benchmark::State& state)
 	}
 
 	logger().fine(
-	        "variables: " + ((ScopeLink&) (*h)).get_variables().to_string());
+	        "variables: " + ScopeLinkCast(h)->get_variables().to_string());
 }
 BENCHMARK(BM_CreateScopeLinkWithoutVariableList);
 
@@ -110,7 +110,7 @@ static void BM_CreateScopeLinkWithLambdaLink(benchmark::State& state)
 	}
 
 	logger().fine(
-	        "variables: " + ((ScopeLink&) (*h)).get_variables().to_string());
+	        "variables: " + ScopeLinkCast(h)->get_variables().to_string());
 }
 BENCHMARK(BM_CreateScopeLinkWithLambdaLink);
 


### PR DESCRIPTION
Issue https://github.com/opencog/benchmark/issues/8 

I have added benchmarks for creating and adding ScopeLink into atomspace. I have added same EvaluationLink tests to compare performance.

(0) Benchmark results (atomspace and cogutil debug versions) see release results below in comment https://github.com/opencog/benchmark/pull/13#issuecomment-393573327:
```
$ ./atomspace/atomspace/benchmark
2018-05-30 18:30:47
Running ./atomspace/atomspace/benchmark
Run on (12 X 4000 MHz CPU s)
CPU Caches:
  L1 Data 32K (x6)
  L1 Instruction 32K (x6)
  L2 Unified 256K (x6)
  L3 Unified 12288K (x1)
-----------------------------------------------------------------------------
Benchmark                                      Time           CPU Iterations
-----------------------------------------------------------------------------
BM_CreateScopeLinkWithVariableList          5127 ns       5127 ns     132751
BM_CreateScopeLinkWithoutVariableList       3669 ns       3669 ns     192123
BM_CreateScopeLinkWithLambdaLink            2925 ns       2925 ns     232632
BM_AddSameScopeLink                        12310 ns      12310 ns      56377
BM_AddScopeLink/65536                      29296 ns      29296 ns      23745
BM_CreateEvaluationLink                     1405 ns       1405 ns     487478
BM_AddSameEvaluationLink                    4865 ns       4865 ns     145954
BM_AddEvaluationLink/65536                 10993 ns      10993 ns      62096

```

(1) I have used Google Benchmark to create this stuff but it can be discussed. 
Pros:
- benchmark code and benchmark tooling are separated - we can separate benchmark code and tools in atomspace_bm as well but it may be simpler to use well known already implemented tool
- library is actively maintained and has some community around it 

Contras:
- new format of results representation - it requires diary.txt results transition and I am not sure it is handful for others
- Google Benchmark is not present in Ubuntu repository so it should be installed by hand but installation process is not that hard and have no other dependencies

(2) I have found comparing BM_AddSameScopeLink and BM_AddSameEvaluationLink profiles that main additional complexity for ScopeLink adding is copying ScopeLink. It leads to second ScopeLink.init() method call which is heavy.

BM_AddSameScopeLink profile:
```
      - 83,87% _ZL19BM_AddSameScopeLinkRN9benchmark5StateE                                           ▒
         - 83,80% _ZN7opencog9AtomSpace8add_atomERKNS_6HandleEb                                      ▒
            - 78,35% _ZN7opencog9AtomTable3addESt10shared_ptrINS_4AtomEEb                            ▒
               - 46,39% _ZN7opencog10createLinkIJRSt6vectorINS_6HandleESaIS2_EERtEEES2_DpOT_         ▒
                  - 36,55% _ZNK7opencog11ClassServer7factoryERKNS_6HandleE                           ▒
                     - 36,23% _ZN7opencog9ScopeLink7factoryERKNS_6HandleE                            ▒
                        - 33,79% _ZSt11make_sharedIN7opencog9ScopeLinkEJRKSt6vectorINS0_6HandleESaIS3▒
                           - 33,60% _ZSt15allocate_sharedIN7opencog9ScopeLinkESaIS1_EJRKSt6vectorINS0▒
                              - 33,43% _ZNSt10shared_ptrIN7opencog9ScopeLinkEEC2ISaIS1_EJRKSt6vectorI▒
                                 - 33,36% _ZNSt12__shared_ptrIN7opencog9ScopeLinkELN9__gnu_cxx12_Lock▒
                                    - 23,29% _ZNSt14__shared_countILN9__gnu_cxx12_Lock_policyE2EEC2IN▒
                                       - 22,56% _ZNSt23_Sp_counted_ptr_inplaceIN7opencog9ScopeLinkESa▒
                                          - 22,30% _ZNSt16allocator_traitsISaIN7opencog9ScopeLinkEEE9▒
                                             - 22,19% _ZN9__gnu_cxx13new_allocatorIN7opencog9ScopeLin▒
                                                - 22,07% _ZN7opencog9ScopeLinkC2ERKSt6vectorINS_6Hand▒
                                                   + 18,55% _ZN7opencog9ScopeLink4initEv             ▒
                                                   + 1,41% _ZN7opencog4LinkC2ERKSt6vectorINS_6HandleE▒
                                                   + 1,39% _ZN7opencog9VariablesC2Ev (inlined)       ▒
                                                     0,52% _ZN7opencog9ScopeLink9skip_initEt         ▒
```

BM_AddSameEvaluationLink profile:
```
   - 88,48% _ZL24BM_AddSameEvaluationLinkRN9benchmark5StateE                                         ▒
      - 88,44% _ZN7opencog9AtomSpace8add_atomERKNS_6HandleEb                                         ▒
         - 82,46% _ZN7opencog9AtomTable3addESt10shared_ptrINS_4AtomEEb                               ▒
            - 32,87% _ZN7opencog10createLinkIJRSt6vectorINS_6HandleESaIS2_EERtEEES2_DpOT_            ▒
               - 17,07% _ZNK7opencog11ClassServer7factoryERKNS_6HandleE                              ▒
                  - 16,54% _ZN7opencog8FreeLink7factoryERKNS_6HandleE                                ▒
                     - 12,09% _ZSt11make_sharedIN7opencog8FreeLinkEJRKSt6vectorINS0_6HandleESaIS3_EEt▒
                        - 11,88% _ZSt15allocate_sharedIN7opencog8FreeLinkESaIS1_EJRKSt6vectorINS0_6Ha▒
                           - 11,75% _ZNSt10shared_ptrIN7opencog8FreeLinkEEC2ISaIS1_EJRKSt6vectorINS0_▒
                              - 11,56% _ZNSt12__shared_ptrIN7opencog8FreeLinkELN9__gnu_cxx12_Lock_pol▒
                                 + 5,81% _ZNSt14__shared_countILN9__gnu_cxx12_Lock_policyE2EEC2IN7ope▒
                                 + 2,69% _ZNSt14__shared_countILN9__gnu_cxx12_Lock_policyE2EEC2IN7ope▒
                                 + 1,93% _ZNSt14__shared_countILN9__gnu_cxx12_Lock_policyE2EEC2IN7ope▒
                                   0,53% _ZNSt12__shared_ptrIN7opencog8FreeLinkELN9__gnu_cxx12_Lock_p
```