### PR TITLE
Rename protoatom to value

### DIFF
--- a/atomspace/atomspace/AtomSpaceBenchmark.cc
+++ b/atomspace/atomspace/AtomSpaceBenchmark.cc
@@ -12,7 +12,7 @@
 #include <opencog/util/oc_assert.h>
 #include <opencog/util/random.h>
 
-#include <opencog/atoms/proto/types.h>
+#include <opencog/atoms/value/types.h>
 #include <opencog/atoms/base/Node.h>
 #include <opencog/atoms/base/Link.h>
 #include <opencog/truthvalue/AttentionValue.h>

--- a/atomspace/atomspace/AtomSpaceBenchmark.h
+++ b/atomspace/atomspace/AtomSpaceBenchmark.h
@@ -7,7 +7,7 @@
 #include <opencog/util/mt19937ar.h>
 
 #include <opencog/atomspace/AtomSpace.h>
-#include <opencog/atoms/proto/types.h>
+#include <opencog/atoms/value/types.h>
 // #undef HAVE_CYTHON
 // #undef HAVE_GUILE
 

--- a/atomspace/atomspace/diary.txt
+++ b/atomspace/atomspace/diary.txt
@@ -978,7 +978,7 @@ Its all broken. Remeasure, below.
 ======================================================================
 2 October 2015
 
-ProtoAtom testing.
+ProtoAtom[now renamed 'Value'] testing.
 Implementing the ProtoAtom requires that some of the Handle operators,
 for casting to AtomPtr and for operator->() are no longer in the header
 file. Does this impact performance? Lets see...


### PR DESCRIPTION
This is the corresponding fix for PR [#1930.](https://github.com/opencog/atomspace/pull/1930) as per the issue [Rename FloatValue to FloatSeq? #1880](https://github.com/opencog/atomspace/issues/1880#issuecomment-430348458).