### PR TITLE
Add benchmark of the Variables::extend() method 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,7 +51,7 @@ ENDIF (ATOMSPACE_FOUND)
 
 # ----------------------------------------------------------
 # Google benchmark package (optional)
-FIND_PACKAGE(benchmark)
+FIND_PACKAGE(benchmark 1.3.0)
 IF (benchmark_FOUND)
 	MESSAGE(STATUS "Google Benchmark ${benchmark_VERSION} found.")
 ELSE (benchmark_FOUND)

--- a/micro/CMakeLists.txt
+++ b/micro/CMakeLists.txt
@@ -11,6 +11,5 @@ IF (benchmark_FOUND)
 		${ATOMSPACE_LIBRARIES}
 		${COGUTIL_LIBRARY}
 		benchmark::benchmark
-		benchmark::benchmark_main
 	)
 ENDIF(benchmark_FOUND)

--- a/micro/CMakeLists.txt
+++ b/micro/CMakeLists.txt
@@ -5,6 +5,7 @@ IF (benchmark_FOUND)
 		benchmark.cc
 		scopelink_bm.cc
 		evaluationlink_bm.cc
+		variables_bm.cc
 	)
 
 	TARGET_LINK_LIBRARIES (benchmark

--- a/micro/README.md
+++ b/micro/README.md
@@ -1,9 +1,15 @@
 # Micro-Benchmarking
 
 ## Prerequisites
-This requires the "Google Benchmark" micro-benchmarking tool.
+This requires the "Google Benchmark" micro-benchmarking tool v1.3.0 or higher.
 
 Google Benchmark is a library supporting C++ micro-benchmarking.
+
+Install it from repository:
+```
+apt-get install libbenchmark-dev
+```
+
 Build and install it:
 
 ```

--- a/micro/variables_bm.cc
+++ b/micro/variables_bm.cc
@@ -24,25 +24,81 @@
 
 #include <opencog/util/Logger.h>
 #include <opencog/atomspace/AtomSpace.h>
+#include <opencog/atomspace/AtomSpace.h>
+#include <opencog/atoms/core/Variables.h>
+#include <opencog/atoms/core/VariableList.h>
 
 #include "benchmark.h"
 
 using namespace opencog;
 
-static void BM_ExtendVariablesNewVariable(benchmark::State& state)
+static void BM_VariablesExtend_NewVariable(benchmark::State& state)
 {
 	AtomSpace atomspace;
 	Handle varX = atomspace.add_node(VARIABLE_NODE, "$X");
 	Handle varY = atomspace.add_node(VARIABLE_NODE, "$Y");
-	Handle varDeclA = atomspace.add_link(VARIABLE_LIST, VarX);
-	Handle varDeclB = atomspace.add_link(VARIABLE_LIST, VarY);
-	VariableList vl1(varDeclA), vl2(varDeclB);
+	Handle varDeclA = atomspace.add_link(VARIABLE_LIST, varX);
+	Handle varDeclB = atomspace.add_link(VARIABLE_LIST, varY);
+	Variables varsA(VariableList(varDeclA).get_variables());
+	Variables varsB(VariableList(varDeclB).get_variables());
 
 	for (auto _ : state)
 	{
-		vl1.extend(vl2);
+		varsA.extend(varsB);
 	}
 }
-BENCHMARK(BM_ExtendVariablesNewVariable);
+BENCHMARK(BM_VariablesExtend_NewVariable);
+
+static void BM_VariablesExtend_SameVariableNoTypeRestrictions(benchmark::State& state)
+{
+	AtomSpace atomspace;
+	Handle varX = atomspace.add_node(VARIABLE_NODE, "$X");
+	Handle conceptNodeType = atomspace.add_node(TYPE_NODE, "ConceptNode");
+	Handle varXTyped = atomspace.add_link(TYPED_VARIABLE_LINK, varX, conceptNodeType);
+	Handle varDeclA = atomspace.add_link(VARIABLE_LIST, varXTyped);
+	Handle varDeclB = atomspace.add_link(VARIABLE_LIST, varX);
+	Variables varsA(VariableList(varDeclA).get_variables());
+	Variables varsB(VariableList(varDeclB).get_variables());
+
+	for (auto _ : state)
+	{
+		varsA.extend(varsB);
+	}
+}
+BENCHMARK(BM_VariablesExtend_SameVariableNoTypeRestrictions);
+
+static void BM_VariablesExtend_NewVariableNoTypeRestrictions(benchmark::State& state)
+{
+	AtomSpace atomspace;
+	Handle varX = atomspace.add_node(VARIABLE_NODE, "$X");
+	Handle varDeclA = atomspace.add_link(VARIABLE_LIST);
+	Handle varDeclB = atomspace.add_link(VARIABLE_LIST, varX);
+	Variables varsA(VariableList(varDeclA).get_variables());
+	Variables varsB(VariableList(varDeclB).get_variables());
+
+	for (auto _ : state)
+	{
+		varsA.extend(varsB);
+	}
+}
+BENCHMARK(BM_VariablesExtend_NewVariableNoTypeRestrictions);
+
+static void BM_VariablesExtend_SameVariableWithTypeRestrictions(benchmark::State& state)
+{
+	AtomSpace atomspace;
+	Handle varX = atomspace.add_node(VARIABLE_NODE, "$X");
+	Handle conceptNodeType = atomspace.add_node(TYPE_NODE, "ConceptNode");
+	Handle varXTyped = atomspace.add_link(TYPED_VARIABLE_LINK, varX, conceptNodeType);
+	Handle varDeclA = atomspace.add_link(VARIABLE_LIST, varXTyped);
+	Handle varDeclB = atomspace.add_link(VARIABLE_LIST, varXTyped);
+	Variables varsA(VariableList(varDeclA).get_variables());
+	Variables varsB(VariableList(varDeclB).get_variables());
+
+	for (auto _ : state)
+	{
+		varsA.extend(varsB);
+	}
+}
+BENCHMARK(BM_VariablesExtend_SameVariableWithTypeRestrictions);
 
 

--- a/micro/variables_bm.cc
+++ b/micro/variables_bm.cc
@@ -1,0 +1,48 @@
+/*
+ * variables_bm.cc
+ *
+ * Copyright (C) 2019 OpenCog Foundation
+ * All Rights Reserved
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License v3 as
+ * published by the Free Software Foundation and including the exceptions
+ * at http://opencog.org/wiki/Licenses
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program; if not, write to:
+ * Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include <benchmark/benchmark.h>
+
+#include <opencog/util/Logger.h>
+#include <opencog/atomspace/AtomSpace.h>
+
+#include "benchmark.h"
+
+using namespace opencog;
+
+static void BM_ExtendVariablesNewVariable(benchmark::State& state)
+{
+	AtomSpace atomspace;
+	Handle varX = atomspace.add_node(VARIABLE_NODE, "$X");
+	Handle varY = atomspace.add_node(VARIABLE_NODE, "$Y");
+	Handle varDeclA = atomspace.add_link(VARIABLE_LIST, VarX);
+	Handle varDeclB = atomspace.add_link(VARIABLE_LIST, VarY);
+	VariableList vl1(varDeclA), vl2(varDeclB);
+
+	for (auto _ : state)
+	{
+		vl1.extend(vl2);
+	}
+}
+BENCHMARK(BM_ExtendVariablesNewVariable);
+
+


### PR DESCRIPTION
Benchmark for the https://github.com/opencog/atomspace/pull/2427

Results before change:
```
$ ./micro/benchmark --benchmark_filter=BM_VariablesExtend
2019-12-10 18:08:19
Running ./micro/benchmark
Run on (12 X 4000 MHz CPU s)
CPU Caches:
  L1 Data 32 KiB (x6)
  L1 Instruction 32 KiB (x6)
  L2 Unified 256 KiB (x6)
  L3 Unified 12288 KiB (x1)
Load Average: 0.77, 0.61, 0.65
----------------------------------------------------------------------------------------------
Benchmark                                                    Time             CPU   Iterations
----------------------------------------------------------------------------------------------
BM_VariablesExtend_NewVariable                            1880 ns         1880 ns       372825
BM_VariablesExtend_SameVariableNoTypeRestrictions         1871 ns         1871 ns       371455
BM_VariablesExtend_NewVariableNoTypeRestrictions          1864 ns         1864 ns       374311
BM_VariablesExtend_SameVariableWithTypeRestrictions        140 ns          140 ns      4958600
```

After change:
```
$ ./micro/benchmark --benchmark_filter=BM_VariablesExtend
2019-12-10 18:09:12
Running ./micro/benchmark
Run on (12 X 4000 MHz CPU s)
CPU Caches:
  L1 Data 32 KiB (x6)
  L1 Instruction 32 KiB (x6)
  L2 Unified 256 KiB (x6)
  L3 Unified 12288 KiB (x1)
Load Average: 1.08, 0.73, 0.69
----------------------------------------------------------------------------------------------
Benchmark                                                    Time             CPU   Iterations
----------------------------------------------------------------------------------------------
BM_VariablesExtend_NewVariable                            14.7 ns         14.7 ns     47369143
BM_VariablesExtend_SameVariableNoTypeRestrictions         12.0 ns         12.0 ns     58611996
BM_VariablesExtend_NewVariableNoTypeRestrictions          10.8 ns         10.8 ns     65308978
BM_VariablesExtend_SameVariableWithTypeRestrictions        146 ns          146 ns      4800956
```