### PR TITLE
Measure same operation each iteration.

### DIFF
--- a/micro/variables_bm.cc
+++ b/micro/variables_bm.cc
@@ -39,11 +39,12 @@ static void BM_VariablesExtend_NewVariable(benchmark::State& state)
 	Handle varY = atomspace.add_node(VARIABLE_NODE, "$Y");
 	Handle varDeclA = atomspace.add_link(VARIABLE_LIST, varX);
 	Handle varDeclB = atomspace.add_link(VARIABLE_LIST, varY);
-	Variables varsA(VariableList(varDeclA).get_variables());
+	auto& listA = VariableList(varDeclA).get_variables();
 	Variables varsB(VariableList(varDeclB).get_variables());
 
 	for (auto _ : state)
 	{
+		Variables varsA(listA);
 		varsA.extend(varsB);
 	}
 }
@@ -57,11 +58,12 @@ static void BM_VariablesExtend_SameVariableNoTypeRestrictions(benchmark::State& 
 	Handle varXTyped = atomspace.add_link(TYPED_VARIABLE_LINK, varX, conceptNodeType);
 	Handle varDeclA = atomspace.add_link(VARIABLE_LIST, varXTyped);
 	Handle varDeclB = atomspace.add_link(VARIABLE_LIST, varX);
-	Variables varsA(VariableList(varDeclA).get_variables());
+	auto& listA = VariableList(varDeclA).get_variables();
 	Variables varsB(VariableList(varDeclB).get_variables());
 
 	for (auto _ : state)
 	{
+		Variables varsA(listA);
 		varsA.extend(varsB);
 	}
 }
@@ -73,11 +75,12 @@ static void BM_VariablesExtend_NewVariableNoTypeRestrictions(benchmark::State& s
 	Handle varX = atomspace.add_node(VARIABLE_NODE, "$X");
 	Handle varDeclA = atomspace.add_link(VARIABLE_LIST);
 	Handle varDeclB = atomspace.add_link(VARIABLE_LIST, varX);
-	Variables varsA(VariableList(varDeclA).get_variables());
+	auto& listA = VariableList(varDeclA).get_variables();
 	Variables varsB(VariableList(varDeclB).get_variables());
 
 	for (auto _ : state)
 	{
+		Variables varsA(listA);
 		varsA.extend(varsB);
 	}
 }
@@ -91,11 +94,12 @@ static void BM_VariablesExtend_SameVariableWithTypeRestrictions(benchmark::State
 	Handle varXTyped = atomspace.add_link(TYPED_VARIABLE_LINK, varX, conceptNodeType);
 	Handle varDeclA = atomspace.add_link(VARIABLE_LIST, varXTyped);
 	Handle varDeclB = atomspace.add_link(VARIABLE_LIST, varXTyped);
-	Variables varsA(VariableList(varDeclA).get_variables());
+	auto& listA = VariableList(varDeclA).get_variables();
 	Variables varsB(VariableList(varDeclB).get_variables());
 
 	for (auto _ : state)
 	{
+		Variables varsA(listA);
 		varsA.extend(varsB);
 	}
 }


### PR DESCRIPTION
New results:
```
$ ./micro/benchmark --benchmark_filter=BM_VariablesExtend
2019-12-11 11:55:54
Running ./micro/benchmark
Run on (12 X 4000 MHz CPU s)
CPU Caches:
  L1 Data 32 KiB (x6)
  L1 Instruction 32 KiB (x6)
  L2 Unified 256 KiB (x6)
  L3 Unified 12288 KiB (x1)
Load Average: 0.50, 0.64, 0.74
----------------------------------------------------------------------------------------------
Benchmark                                                    Time             CPU   Iterations
----------------------------------------------------------------------------------------------
BM_VariablesExtend_NewVariable                            86.2 ns         86.2 ns      7735128
BM_VariablesExtend_SameVariableNoTypeRestrictions         91.7 ns         91.7 ns      8010651
BM_VariablesExtend_NewVariableNoTypeRestrictions          91.7 ns         91.7 ns      7973165
BM_VariablesExtend_SameVariableWithTypeRestrictions        221 ns          221 ns      3136600
```